### PR TITLE
feature: Add pattern parameter fallback FT-6638

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:tslint": "tslint --fix --project .",
     "fix:markdown": "remark --rc-path .remarkrc.js *.md -o",
-    "test": "run-s build test:*",
+    "test": "run-s build docs:gen test:*",
     "test:tslint": "tslint --project .",
     "test:prettier": "prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc ava",

--- a/src/lib/codacy-configuration.ts
+++ b/src/lib/codacy-configuration.ts
@@ -122,7 +122,6 @@ function loadDefaultPatterns(
     process.exit(50);
     return;
   }
-  return;
 }
 
 function getDefaultParameterForPattern(

--- a/src/lib/integration.spec.ts
+++ b/src/lib/integration.spec.ts
@@ -28,3 +28,27 @@ test('run integration test no-magic-numbers and interface-name', async t => {
     }
   ]);
 });
+
+test('pattern without configuration should fallback to default values in patterns.json', async t => {
+  const testsPath = path.join(
+    process.cwd(),
+    'test_samples/repositories/integration'
+  );
+
+  const patternsPath = path.join(process.cwd(), 'docs/patterns.json');
+
+  const results = await run({
+    codacyConfigPath: `${testsPath}/codacyrc-pattern-fallback`,
+    fallbackPatterns: patternsPath,
+    sourcePath: testsPath
+  });
+
+  t.deepEqual(results, [
+    {
+      file: 'test-pattern-fallback.ts',
+      line: 1,
+      message: 'Exceeds maximum line length of 120',
+      patternId: 'max-line-length'
+    }
+  ]);
+});

--- a/src/lib/tslint-runner.ts
+++ b/src/lib/tslint-runner.ts
@@ -16,16 +16,24 @@ export default function run(
   options: {
     readonly sourcePath?: string;
     readonly codacyConfigPath?: string;
-    readonly getCodacyConfiguration?: (path: string) => Configuration;
+    readonly fallbackPatterns?: string;
+    readonly getCodacyConfiguration?: (
+      path: string,
+      fallbackPatternsPath: string
+    ) => Configuration;
   } = {}
 ): ReadonlyArray<CodacyIssue> {
   const {
     sourcePath = '/src',
     codacyConfigPath = '/.codacyrc',
+    fallbackPatterns = '/docs/patterns.json',
     getCodacyConfiguration = configFromCodacy
   } = options;
 
-  const { rawConfig, files } = getCodacyConfiguration(codacyConfigPath);
+  const { rawConfig, files } = getCodacyConfiguration(
+    codacyConfigPath,
+    fallbackPatterns
+  );
   const configuration = rawConfig
     ? parseConfigFile(rawConfig)
     : tslint.Configuration.findConfiguration(null, sourcePath).results;

--- a/test_samples/repositories/integration/codacyrc-pattern-fallback
+++ b/test_samples/repositories/integration/codacyrc-pattern-fallback
@@ -1,0 +1,13 @@
+{
+  "tools": [
+    {
+      "name": "tslint",
+      "patterns": [
+        {
+          "patternId": "max-line-length"
+        }
+      ]
+    }
+  ],
+  "files": ["test-pattern-fallback.ts"]
+}

--- a/test_samples/repositories/integration/test-pattern-fallback.ts
+++ b/test_samples/repositories/integration/test-pattern-fallback.ts
@@ -1,0 +1,1 @@
+var x = "gmpdgrdkogmprdmgmrdjmgodrjmmgodirmgmdrmpaosmgmjmgiopdrsjgdioprjgsiopjmgeispjmghprdjkpodersgpdrjmgdrpkgkapkmsfgijksp0ºakgmiropdjgprdkgkdprokpgapjkmfgpes";


### PR DESCRIPTION
When some patterns are enabled (e.g. max-line-length) and no parameters are provided, the tools fails to execute with an error. This fallback mechanism reads the default parameters from the generated patterns.json file